### PR TITLE
Add analysis for deprecated APIS

### DIFF
--- a/docs/DE0001.md
+++ b/docs/DE0001.md
@@ -1,0 +1,31 @@
+<!--
+T:System.Security.SecureString
+-->
+
+# DE0001: SecureString shouldn't be used
+
+## Motivation
+
+* The purpose of `SecureString` is to avoid having secrets stored in the process
+  memory as plain text.
+* However, even on Windows `SecureString` doesn't exist as an OS concept
+    - It just makes the window getting the plain text shorter; it doesn't fully
+      prevent it as .NET still has to convert the string to a plain text
+      representation
+    - The benefit is that the plain text representation doesn't hang around
+      as an instance of `System.String` -- the lifetime of the native buffer is
+      shorter.
+* The contents of the array is unencrypted except on .NET Framework.
+    - In .NET Framework, the contents of the internal char array is encrypted.
+      We've trouble with supporting the encryption in all environments, either
+      due to missing APIs or key management issues.
+
+## Recommendation
+
+Don't use `SecureString` for new code. When porting code to .NET Core, consider
+that the contents of the array will not be encrypted in memory.
+
+The general approach of dealing with credentials is to avoid them and instead
+rely on other means to authenticate, such as certificates or Windows
+authentication.
+

--- a/docs/DE0002.md
+++ b/docs/DE0002.md
@@ -1,0 +1,19 @@
+<!--
+N:System.Security.Permissions
+-->
+
+# DE0002: Code Access Security (CAS) shouldn't be used
+
+## Motivation
+
+When .NET Framework was originally it tried to provide a managed sandbox that
+allows restricting what parts of the process can do. Unfortunately, providing an
+additional security boundary on top of the operating system has been proven to
+be too difficult. As a result, there have been quite a few exploits that allows
+code to escape the managed sandbox.
+
+## Recommendation
+
+We recommend not to use CAS for new code. For security purposes you should rely
+on operating system provided security boundaries, for example on Windows you can
+use Access Control Lists (ACLs).

--- a/docs/DE0003.md
+++ b/docs/DE0003.md
@@ -1,0 +1,17 @@
+<!--
+T:System.Net.WebRequest
+T:System.Net.FtpWebRequest
+T:System.Net.FileWebRequest
+T:System.Net.HttpWebRequest
+-->
+
+# DE0003: WebRequest shouldn't be used
+
+## Motivation
+
+ `WebRequest`-based APIs are on life-support only (i.e. only critical fixes, no
+ new improvements, enhancements).
+
+## Recommendation
+
+Use `HttpClient` instead.

--- a/docs/DE0004.md
+++ b/docs/DE0004.md
@@ -1,0 +1,14 @@
+<!--
+T:System.Net.WebClient
+-->
+
+# DE0004: WebClient shouldn't be used
+
+## Motivation
+
+ `WebClient` is on life-support only (i.e. only critical fixes, no new
+ improvements, enhancements).
+
+## Recommendation
+
+Use `HttpClient` instead.

--- a/docs/DE0005.md
+++ b/docs/DE0005.md
@@ -1,0 +1,15 @@
+<!--
+T:System.Net.Mail.SmtpClient
+-->
+
+# DE0005: SmtpClient shouldn't be used
+
+## Motivation
+
+`SmtpClient` does not support many modern protocols. It is compat-only. It's
+great for one off emails from tools, but does not scale to modern requirements
+of the protocol.
+
+## Recommendation
+
+Use `MailKit` or other libraries.

--- a/docs/DE0006.md
+++ b/docs/DE0006.md
@@ -1,0 +1,55 @@
+<!--
+T:System.Collections.ArrayList
+T:System.Collections.Hashtable
+T:System.Collections.Queue
+T:System.Collections.Stack
+T:System.Collections.SortedList
+T:System.Collections.DictionaryEntry
+T:System.Collections.DictionaryBase
+T:System.Collections.CollectionBase
+T:System.Collections.ReadOnlyCollectionBase
+T:System.Collections.Comparer
+T:System.Collections.CaseInsensitiveComparer
+T:System.Collections.CaseInsensitiveHashCodeProvider
+-->
+
+# DE0006: Non-generic collections shouldn't be used
+
+## Motivation
+
+When .NET was created, generic data types didn't exist, which is why the
+collection types in `System.Collections` are untyped. However, since generic
+data types and thus a new set of collections in `System.Collections.Generic` are
+made available.
+
+## Recommendation
+
+For new code, you shouldn't use non-generic collections:
+
+* **Error prone**. Since non-generic collections are untyped, it requires frequent
+  casting between `object` and the actual type you're expecting. Since the compiler
+  can't check that your types are consistent it's easer to put the wrong type in
+  the wrong collection.
+
+* **Less performant**. Generic collection have the advantage that value types
+  don't have to be boxed as object. For instance, a `List<int>` stores its data
+  in an `int[]`. That's far better than storing the data in `object[]` as that
+  requires boxing.
+
+Consult the following table which how the non-generic collection types can be
+replaced by their generic counterparts.
+
+| Type                              | Replacement                                                |
+|-----------------------------------|------------------------------------------------------------|
+| `ArrayList`                       | `List<T>`                                                  |
+| `Hashtable`                       | `Dictionary<TKey, TValue>`                                 |
+| `Queue`                           | `Queue<T>`                                                 |
+| `Stack`                           | `Stack<T>`                                                 |
+| `SortedList`                      | `SortedList<TKey, TValue>`                                 |
+| `DictionaryEntry`                 | `KeyValuePair<TKey, TValue>`                               |
+| `DictionaryBase`                  | `Dictionary<TKey, TValue> or KeyedCollection<TKey, TItem>` |
+| `CollectionBase`                  | `Collection<T>`                                            |
+| `ReadOnlyCollectionBase`          | `ReadOnlyCollection<T>`                                    |
+| `Comparer`                        | `Comparer<T>`                                              |
+| `CaseInsensitiveComparer`         | `StringComparer.OrdinalIgnoreCase`                         |
+| `CaseInsensitiveHashCodeProvider` | `StringComparer.OrdinalIgnoreCase`                         |

--- a/etc/deprecated.csv
+++ b/etc/deprecated.csv
@@ -1,3 +1,7 @@
 DocId,Namespace,Type,Member,DiagnosticIds
+T:System.Net.FileWebRequest,System.Net,FileWebRequest,,DE0003
+T:System.Net.FtpWebRequest,System.Net,FtpWebRequest,,DE0003
+T:System.Net.HttpWebRequest,System.Net,HttpWebRequest,,DE0003
+T:System.Net.WebRequest,System.Net,WebRequest,,DE0003
 T:System.Security.SecureString,System.Security,SecureString,,DE0001
 N:System.Security.Permissions,System.Security.Permissions,,,DE0002

--- a/etc/deprecated.csv
+++ b/etc/deprecated.csv
@@ -1,4 +1,16 @@
 DocId,Namespace,Type,Member,DiagnosticIds
+T:System.Collections.ArrayList,System.Collections,ArrayList,,DE0006
+T:System.Collections.CaseInsensitiveComparer,System.Collections,CaseInsensitiveComparer,,DE0006
+T:System.Collections.CaseInsensitiveHashCodeProvider,System.Collections,CaseInsensitiveHashCodeProvider,,DE0006
+T:System.Collections.CollectionBase,System.Collections,CollectionBase,,DE0006
+T:System.Collections.Comparer,System.Collections,Comparer,,DE0006
+T:System.Collections.DictionaryBase,System.Collections,DictionaryBase,,DE0006
+T:System.Collections.DictionaryEntry,System.Collections,DictionaryEntry,,DE0006
+T:System.Collections.Hashtable,System.Collections,Hashtable,,DE0006
+T:System.Collections.Queue,System.Collections,Queue,,DE0006
+T:System.Collections.ReadOnlyCollectionBase,System.Collections,ReadOnlyCollectionBase,,DE0006
+T:System.Collections.SortedList,System.Collections,SortedList,,DE0006
+T:System.Collections.Stack,System.Collections,Stack,,DE0006
 T:System.Net.FileWebRequest,System.Net,FileWebRequest,,DE0003
 T:System.Net.FtpWebRequest,System.Net,FtpWebRequest,,DE0003
 T:System.Net.HttpWebRequest,System.Net,HttpWebRequest,,DE0003

--- a/etc/deprecated.csv
+++ b/etc/deprecated.csv
@@ -1,2 +1,3 @@
 DocId,Namespace,Type,Member,DiagnosticIds
 T:System.Security.SecureString,System.Security,SecureString,,DE0001
+N:System.Security.Permissions,System.Security.Permissions,,,DE0002

--- a/etc/deprecated.csv
+++ b/etc/deprecated.csv
@@ -1,0 +1,1 @@
+DocId,Namespace,Type,Member,DiagnosticIds

--- a/etc/deprecated.csv
+++ b/etc/deprecated.csv
@@ -2,6 +2,7 @@ DocId,Namespace,Type,Member,DiagnosticIds
 T:System.Net.FileWebRequest,System.Net,FileWebRequest,,DE0003
 T:System.Net.FtpWebRequest,System.Net,FtpWebRequest,,DE0003
 T:System.Net.HttpWebRequest,System.Net,HttpWebRequest,,DE0003
+T:System.Net.WebClient,System.Net,WebClient,,DE0004
 T:System.Net.WebRequest,System.Net,WebRequest,,DE0003
 T:System.Security.SecureString,System.Security,SecureString,,DE0001
 N:System.Security.Permissions,System.Security.Permissions,,,DE0002

--- a/etc/deprecated.csv
+++ b/etc/deprecated.csv
@@ -1,1 +1,2 @@
 DocId,Namespace,Type,Member,DiagnosticIds
+T:System.Security.SecureString,System.Security,SecureString,,DE0001

--- a/etc/deprecated.csv
+++ b/etc/deprecated.csv
@@ -4,5 +4,6 @@ T:System.Net.FtpWebRequest,System.Net,FtpWebRequest,,DE0003
 T:System.Net.HttpWebRequest,System.Net,HttpWebRequest,,DE0003
 T:System.Net.WebClient,System.Net,WebClient,,DE0004
 T:System.Net.WebRequest,System.Net,WebRequest,,DE0003
+T:System.Net.Mail.SmtpClient,System.Net.Mail,SmtpClient,,DE0005
 T:System.Security.SecureString,System.Security,SecureString,,DE0001
 N:System.Security.Permissions,System.Security.Permissions,,,DE0002

--- a/platform-compat.sln
+++ b/platform-compat.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.0
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrajobst.PlatformCompat.Analyzers.Vsix", "src\Terrajobst.PlatformCompat.Analyzers.Vsix\Terrajobst.PlatformCompat.Analyzers.Vsix.csproj", "{95368DD4-2B76-4304-B7EC-6E27C72F641B}"
 EndProject
@@ -19,7 +19,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terrajobst.PlatformCompat.A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terrajobst.PlatformCompat.Analyzers.Tests", "src\Terrajobst.PlatformCompat.Analyzers.Tests\Terrajobst.PlatformCompat.Analyzers.Tests.csproj", "{513A0D76-352B-4DF6-945A-358B0CB2EABA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrajobst.PlatformCompat.Scanner.Tests", "src\Terrajobst.PlatformCompat.Scanner.Tests\Terrajobst.PlatformCompat.Scanner.Tests.csproj", "{F77DF5B7-FC77-4DA7-BE7B-DC402DEDD064}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terrajobst.PlatformCompat.Scanner.Tests", "src\Terrajobst.PlatformCompat.Scanner.Tests\Terrajobst.PlatformCompat.Scanner.Tests.csproj", "{F77DF5B7-FC77-4DA7-BE7B-DC402DEDD064}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dep-index", "src\dep-index\dep-index.csproj", "{6973B489-E5ED-4F82-BE2A-A4A54868F45D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,10 @@ Global
 		{F77DF5B7-FC77-4DA7-BE7B-DC402DEDD064}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F77DF5B7-FC77-4DA7-BE7B-DC402DEDD064}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F77DF5B7-FC77-4DA7-BE7B-DC402DEDD064}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6973B489-E5ED-4F82-BE2A-A4A54868F45D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6973B489-E5ED-4F82-BE2A-A4A54868F45D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6973B489-E5ED-4F82-BE2A-A4A54868F45D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6973B489-E5ED-4F82-BE2A-A4A54868F45D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Terrajobst.Cci/MemberExtensions.cs
+++ b/src/Terrajobst.Cci/MemberExtensions.cs
@@ -5,27 +5,45 @@ namespace Terrajobst.Cci
 {
     public static class MemberExtensions
     {
-        public static string GetNamespaceName(this ITypeDefinitionMember member)
+        public static string GetNamespaceName(this IDefinition definition)
         {
-            return member.ContainingTypeDefinition.GetNamespaceName();
+            if (definition is ITypeDefinitionMember member)
+                return member.ContainingTypeDefinition.GetNamespaceName();
+
+            if (definition is ITypeDefinition type)
+                return type.GetNamespace().GetNamespaceName();
+
+            if (definition is INamespaceDefinition nsp)
+                return nsp.FullName();
+
+            return string.Empty;
         }
 
-        public static string GetTypeName(this ITypeDefinitionMember member)
+        public static string GetTypeName(this IDefinition definition)
         {
-            return member.ContainingTypeDefinition.GetTypeName(false);
+            if (definition is ITypeDefinitionMember member)
+                return member.ContainingTypeDefinition.GetTypeName(false);
+
+            if (definition is ITypeDefinition type)
+                return type.GetTypeName(includeNamespace: false);
+
+            return string.Empty;
         }
 
-        public static string GetMemberSignature(this ITypeDefinitionMember member)
+        public static string GetMemberSignature(this IDefinition definition)
         {
-            if (member is IFieldDefinition)
-                return member.Name.Value;
+            if (definition is IFieldDefinition field)
+                return field.Name.Value;
 
-            return MemberHelper.GetMemberSignature(member, NameFormattingOptions.Signature |
-                                                           NameFormattingOptions.TypeParameters |
-                                                           NameFormattingOptions.ContractNullable |
-                                                           NameFormattingOptions.OmitContainingType |
-                                                           NameFormattingOptions.OmitContainingNamespace |
-                                                           NameFormattingOptions.PreserveSpecialNames);
+            if (definition is ITypeDefinitionMember member)
+                return MemberHelper.GetMemberSignature(member, NameFormattingOptions.Signature |
+                                                               NameFormattingOptions.TypeParameters |
+                                                               NameFormattingOptions.ContractNullable |
+                                                               NameFormattingOptions.OmitContainingType |
+                                                               NameFormattingOptions.OmitContainingNamespace |
+                                                               NameFormattingOptions.PreserveSpecialNames);
+
+            return string.Empty;
         }
     }
 }

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
@@ -155,5 +155,39 @@ namespace Terrajobst.PlatformCompat.Analyzers.Tests
 
             AssertMatch(source, expected);
         }
+
+        [Theory]
+        [InlineData("ArrayList")]
+        [InlineData("Hashtable")]
+        [InlineData("Queue")]
+        [InlineData("Stack")]
+        [InlineData("SortedList")]
+        [InlineData("DictionaryEntry")]
+        [InlineData("DictionaryBase")]
+        [InlineData("CollectionBase")]
+        [InlineData("ReadOnlyCollectionBase")]
+        [InlineData("Comparer")]
+        [InlineData("CaseInsensitiveComparer")]
+        [InlineData("CaseInsensitiveHashCodeProvider")]
+        public void DeprecatedAnalyzer_Triggers_DE0006(string typeName)
+        {
+            var source = @"
+                using System.Collections;
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        {{$TYPE_NAME$}} x = null;
+                    }
+                }
+            ".Replace("$TYPE_NAME$", typeName);
+
+            var expected = $@"
+                DE0006: {typeName} is deprecated
+            ";
+
+            AssertMatch(source, expected);
+        }
     }
 }

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
@@ -105,5 +105,30 @@ namespace Terrajobst.PlatformCompat.Analyzers.Tests
 
             AssertMatch(source, expected);
         }
+
+        [Fact]
+        public void DeprecatedAnalyzer_Triggers_DE0004()
+        {
+            var source = @"
+                using System.Net;
+
+                namespace ConsoleApp1
+                {
+                    class Program
+                    {
+                        static void Main(string[] args)
+                        {
+                            {{WebClient}} x;
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"
+                DE0004: WebClient is deprecated
+            ";
+
+            AssertMatch(source, expected);
+        }
     }
 }

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
@@ -40,5 +40,30 @@ namespace Terrajobst.PlatformCompat.Analyzers.Tests
 
             AssertNoMatch(source);
         }
+
+        [Fact]
+        public void DeprecatedAnalyzer_Triggers_DE0001()
+        {
+            var source = @"
+                using System.Security;
+
+                namespace ConsoleApp1
+                {
+                    class Program
+                    {
+                        static void Main(string[] args)
+                        {
+                            {{SecureString}} x;
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"
+                DE0001: SecureString is deprecated
+            ";
+
+            AssertMatch(source, expected);
+        }
     }
 }

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
@@ -130,5 +130,30 @@ namespace Terrajobst.PlatformCompat.Analyzers.Tests
 
             AssertMatch(source, expected);
         }
+
+        [Fact]
+        public void DeprecatedAnalyzer_Triggers_DE0005()
+        {
+            var source = @"
+                using System.Net.Mail;
+
+                namespace ConsoleApp1
+                {
+                    class Program
+                    {
+                        static void Main(string[] args)
+                        {
+                            {{SmtpClient}} x;
+                        }
+                    }
+                }
+            ";
+
+            var expected = @"
+                DE0005: SmtpClient is deprecated
+            ";
+
+            AssertMatch(source, expected);
+        }
     }
 }

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using Terrajobst.PlatformCompat.Analyzers.Deprecated;
+using Terrajobst.PlatformCompat.Analyzers.Tests.Helpers;
+using Xunit;
+
+namespace Terrajobst.PlatformCompat.Analyzers.Tests
+{
+    public class DeprecatedAnalyzerTests : CSharpDiagnosticTest
+    {
+        protected override DiagnosticAnalyzer CreateAnalyzer()
+        {
+            return new DeprecatedAnalyzer();
+        }
+
+        [Fact]
+        public void DeprecatedAnalyzer_DoesNotTrigger_WhenDocumentEmpty()
+        {
+            AssertNoMatch(string.Empty);
+        }
+
+        [Fact]
+        public void DeprecatedAnalyzer_DoesNotTrigger_WhenApiDefinedInSource()
+        {
+            var source = @"
+                namespace System.Collections
+                {
+                    public class ArrayList
+                    {
+                    }
+
+                    class Program
+                    {
+                        static void Main(string[] args)
+                        {
+                            new ArrayList();
+                        }
+                    }
+                }
+            ";
+
+            AssertNoMatch(source);
+        }
+    }
+}

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
@@ -65,5 +65,19 @@ namespace Terrajobst.PlatformCompat.Analyzers.Tests
 
             AssertMatch(source, expected);
         }
+
+        [Fact]
+        public void DeprecatedAnalyzer_Triggers_DE0002()
+        {
+            var source = @"
+                using System.Security.{{Permissions}};
+            ";
+
+            var expected = @"
+                DE0002: Permissions is deprecated
+            ";
+
+            AssertMatch(source, expected);
+        }
     }
 }

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/DeprecatedAnalyzerTests.cs
@@ -79,5 +79,31 @@ namespace Terrajobst.PlatformCompat.Analyzers.Tests
 
             AssertMatch(source, expected);
         }
+
+        [Theory]
+        [InlineData("WebRequest")]
+        [InlineData("FtpWebRequest")]
+        [InlineData("FileWebRequest")]
+        [InlineData("HttpWebRequest")]
+        public void DeprecatedAnalyzer_Triggers_DE0003(string typeName)
+        {
+            var source = @"
+                using System.Net;
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        {{$TYPE_NAME$}} x = null;
+                    }
+                }
+            ".Replace("$TYPE_NAME$", typeName);
+
+            var expected = $@"
+                DE0003: {typeName} is deprecated
+            ";
+
+            AssertMatch(source, expected);
+        }
     }
 }

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/Helpers/MetadataReferenceSet.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/Helpers/MetadataReferenceSet.cs
@@ -43,7 +43,7 @@ namespace Terrajobst.PlatformCompat.Analyzers.Tests.Helpers
         {
             var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
             var path = Path.Combine(programFilesX86, "Reference Assemblies", "Microsoft", "Framework", ".NETFramework", "v4.6.1");
-            var names = new[] { "mscorlib", "System.Core" };
+            var names = new[] { "mscorlib", "System", "System.Core" };
             return names.Select(n => Path.Combine(path, n + ".dll"))
                         .Select(p => MetadataReference.CreateFromFile(p))
                         .ToImmutableArray<MetadataReference>();

--- a/src/Terrajobst.PlatformCompat.Analyzers/Deprecated/DeprecatedAnalyzer.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers/Deprecated/DeprecatedAnalyzer.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Terrajobst.Csv;
+using Terrajobst.PlatformCompat.Analyzers.Store;
+
+namespace Terrajobst.PlatformCompat.Analyzers.Deprecated
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DeprecatedAnalyzer : DiagnosticAnalyzer
+    {
+        private const string Category = "Usage";
+        private const string HelpLinkFormat = "https://github.com/terrajobst/platform-compat/blob/master/docs/{0}.md";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.DeprecatedAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.DeprecatedAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+        private readonly ApiStore<ImmutableArray<string>> _store = DeprecatedDocument.Parse(Resources.Deprecated);
+
+        private static ImmutableArray<DiagnosticDescriptor> CreateDescriptors()
+        {
+            var diagnosticIds = new SortedSet<string>();
+
+            using (var stringReader = new StringReader(Resources.Deprecated))
+            {
+                var reader = new CsvReader(stringReader);
+                string[] line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (line.Length == 5)
+                    {
+                        var ids = line[4].Split(';');
+                        diagnosticIds.UnionWith(ids);
+                    }
+                }
+            }
+
+            return diagnosticIds.Select(id => new DiagnosticDescriptor(id, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, helpLinkUri: string.Format(HelpLinkFormat, id)))
+                                .ToImmutableArray();
+        }
+
+        public DeprecatedAnalyzer()
+        {
+            SupportedDiagnostics = CreateDescriptors();
+            DescriptorById = SupportedDiagnostics.ToImmutableDictionary(d => d.Id);
+        }
+    
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+        public ImmutableDictionary<string, DiagnosticDescriptor> DescriptorById { get; }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSymbolUsageAction(AnalyzeSymbol);
+        }
+
+        private void AnalyzeSymbol(SymbolUsageAnalysisContext context)
+        {
+            var symbol = context.Symbol;
+
+            // We only want to handle a specific set of symbols
+            var isApplicable = symbol.Kind == SymbolKind.Event ||
+                               symbol.Kind == SymbolKind.Field ||
+                               symbol.Kind == SymbolKind.Method ||
+                               symbol.Kind == SymbolKind.NamedType ||
+                               symbol.Kind == SymbolKind.Namespace ||
+                               symbol.Kind == SymbolKind.Property;
+            if (!isApplicable)
+                return;
+
+            if (!_store.TryLookup(symbol, out var entry))
+                return;
+
+            var api = symbol.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat);
+            var location = context.GetLocation();
+
+            foreach (var diagnosticId in entry.Data)
+            {
+                var descriptor = DescriptorById[diagnosticId];
+                var diagnostic = Diagnostic.Create(descriptor, location, api);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/src/Terrajobst.PlatformCompat.Analyzers/Deprecated/DeprecatedDocument.Parser.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers/Deprecated/DeprecatedDocument.Parser.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Immutable;
+using Terrajobst.PlatformCompat.Analyzers.Exceptions;
+
+namespace Terrajobst.PlatformCompat.Analyzers.Deprecated
+{
+    internal static partial class DeprecatedDocument
+    {
+        private sealed class Parser : ApiStoreParser<ImmutableArray<string>>
+        {
+            protected override ImmutableArray<string> ParseData(ArraySegment<string> values)
+            {
+                if (values.Count != 1)
+                    throw InvalidDocument();
+
+                var value = values.Array[values.Offset];
+                var ids = value.Split(';');
+                return ids.ToImmutableArray();
+            }
+        }
+    }
+}

--- a/src/Terrajobst.PlatformCompat.Analyzers/Deprecated/DeprecatedDocument.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers/Deprecated/DeprecatedDocument.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Immutable;
+using Terrajobst.PlatformCompat.Analyzers.Store;
+
+namespace Terrajobst.PlatformCompat.Analyzers.Deprecated
+{
+    internal static partial class DeprecatedDocument
+    {
+        public static ApiStore<ImmutableArray<string>> Parse(string data)
+        {
+            var parser = new Parser();
+            return parser.Parse(data);
+        }
+    }
+}

--- a/src/Terrajobst.PlatformCompat.Analyzers/Net461/Net461Document.Parser.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers/Net461/Net461Document.Parser.cs
@@ -7,10 +7,6 @@ namespace Terrajobst.PlatformCompat.Analyzers.Net461
     {
         private sealed class Parser : ApiStoreParser<string>
         {
-            protected override void Initialize(ArraySegment<string> headers)
-            {
-            }
-
             protected override string ParseData(ArraySegment<string> values)
             {
                 if (values.Count > 0)

--- a/src/Terrajobst.PlatformCompat.Analyzers/Resources.Designer.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers/Resources.Designer.cs
@@ -62,6 +62,41 @@ namespace Terrajobst.PlatformCompat.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DocId,Namespace,Type,Member,DiagnosticIds
+        ///T:System.Security.SecureString,System.Security,SecureString,,DE0001
+        ///N:System.Security.Permissions,System.Security.Permissions,,,DE0002
+        ///T:System.Net.WebRequest,System.Net,WebRequest,,DE0003
+        ///T:System.Net.FtpWebRequest,System.Net,FtpWebRequest,,DE0003
+        ///T:System.Net.FileWebRequest,System.Net,FileWebRequest,,DE0003
+        ///T:System.Net.HttpWebRequest,System.Net,HttpWebRequest,,DE0003
+        ///T:System.Net.WebClient,System.Net,WebClient,,DE0004
+        ///T:System.Net.Mail.SmtpClient,System.N [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string Deprecated {
+            get {
+                return ResourceManager.GetString("Deprecated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is deprecated.
+        /// </summary>
+        internal static string DeprecatedAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("DeprecatedAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to API is deprecated.
+        /// </summary>
+        internal static string DeprecatedAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("DeprecatedAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} isn&apos;t supported on {1}.
         /// </summary>
         internal static string ExceptionAnalyzerMessageFormat {

--- a/src/Terrajobst.PlatformCompat.Analyzers/Resources.resx
+++ b/src/Terrajobst.PlatformCompat.Analyzers/Resources.resx
@@ -117,6 +117,18 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Deprecated" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\etc\deprecated.csv;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="DeprecatedAnalyzerMessageFormat" xml:space="preserve">
+    <value>{0} is deprecated</value>
+    <comment>The format-able message the diagnostic displays.</comment>
+  </data>
+  <data name="DeprecatedAnalyzerTitle" xml:space="preserve">
+    <value>API is deprecated</value>
+    <comment>The title of the diagnostic.</comment>
+  </data>
   <data name="ExceptionAnalyzerMessageFormat" xml:space="preserve">
     <value>{0} isn't supported on {1}</value>
     <comment>The format-able message the diagnostic displays.</comment>
@@ -125,7 +137,6 @@
     <value>API not supported on all platforms</value>
     <comment>The title of the diagnostic.</comment>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Exceptions" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\etc\exceptions.csv;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Terrajobst.PlatformCompat.Analyzers/Store/ApiStoreParser.cs
+++ b/src/Terrajobst.PlatformCompat.Analyzers/Store/ApiStoreParser.cs
@@ -26,7 +26,9 @@ namespace Terrajobst.PlatformCompat.Analyzers.Exceptions
             }
         }
 
-        protected abstract void Initialize(ArraySegment<string> headers);
+        protected virtual void Initialize(ArraySegment<string> headers)
+        {
+        }
 
         protected abstract T ParseData(ArraySegment<string> values);
 

--- a/src/Terrajobst.PlatformCompat.Analyzers/Terrajobst.PlatformCompat.Analyzers.csproj
+++ b/src/Terrajobst.PlatformCompat.Analyzers/Terrajobst.PlatformCompat.Analyzers.csproj
@@ -33,6 +33,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <Import Project="build\GenerateDeprecated.targets" />
   <Import Project="build\GenerateNuGetPackage.targets" />
 
 </Project>

--- a/src/Terrajobst.PlatformCompat.Analyzers/build/GenerateDeprecated.targets
+++ b/src/Terrajobst.PlatformCompat.Analyzers/build/GenerateDeprecated.targets
@@ -1,0 +1,29 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <DocPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\docs'))</DocPath>
+    <DeprecatedPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\etc\deprecated.csv'))</DeprecatedPath>
+    <DepIndexProjectPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\dep-index\dep-index.csproj'))</DepIndexProjectPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <DeprecatedFiles Include="$(DocPath)\DE*.md" />
+  </ItemGroup>
+
+  <Target Name="GenerateDeprecatedCsv"
+          Inputs="@(DeprecatedFiles)"
+          Outputs="$(DeprecatedPath)"
+          BeforeTargets="BeforeBuild">
+    <MSBuild Projects="$(DepIndexProjectPath)" />
+    <MSBuild Projects="$(DepIndexProjectPath)"
+             Targets="GetTargetPath">
+      <Output TaskParameter="TargetOutputs"
+              ItemName="DepIndex" />
+    </MSBuild>
+    <Exec Command="&quot;@(DepIndex)&quot; &quot;$(DeprecatedPath)&quot; @(DeprecatedFiles->'%(Identity)', ' ')"
+          StandardOutputImportance="Low" />
+    <Message Text="$([System.IO.Path]::GetFileName($(DeprecatedPath))) -> $(DeprecatedPath)"
+             Importance="High" />
+  </Target>
+
+</Project>

--- a/src/dep-index/App.config
+++ b/src/dep-index/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/src/dep-index/Program.cs
+++ b/src/dep-index/Program.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Cci;
+using Microsoft.Cci.Extensions;
+using Terrajobst.Cci;
+using Terrajobst.Csv;
+
+namespace dep_index
+{
+    internal static class Program
+    {
+        private static int Main(string[] args)
+        {
+            string outputPath;
+            string[] inputFiles;
+
+            if (args.Length == 0)
+            {
+                var appPath = Path.GetDirectoryName(Environment.GetCommandLineArgs()[0]);
+                var docsPath = Path.GetFullPath(Path.Combine(appPath, "..", "..", "..", "..", "..", "docs"));
+                inputFiles = Directory.EnumerateFiles(docsPath, "DE*.md").ToArray();
+                outputPath = Path.GetFullPath(Path.Combine(appPath, "..", "..", "..", "..", "..", "etc", "deprecated.csv"));
+            }
+            else
+            {
+                if (args.Length < 2)
+                {
+                    var toolName = Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]);
+                    Console.Error.WriteLine($"Usage: {toolName} <out-path> <input-file>...");
+                    return 1;
+                }
+
+                outputPath = args[0];
+                inputFiles = args.Skip(1).ToArray();
+            }
+
+            try
+            {
+                Run(outputPath, inputFiles);
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                var strackTrace = new StackTrace(ex, true);
+                var frame = strackTrace.GetFrame(0);
+                var fileName = $"{frame.GetFileName()}({frame.GetFileLineNumber()},{frame.GetFileColumnNumber()})";
+                WriteError(ex.Message, fileName);
+                return 1;
+            }
+        }
+
+        private static void WriteError(string text, string fileName = null)
+        {
+            if (fileName == null)
+                Console.Error.WriteLine($"error dep-index: {text}");
+            else
+                Console.Error.WriteLine($"{fileName} : error dep-index: {text}");
+        }
+
+        private static void Run(string outputPath, string[] inputFiles)
+        {
+            var docIdIndex = CreateDocIdIndex();
+            var result = ProcessFiles(inputFiles, docIdIndex);
+            WriteResults(outputPath, result);
+        }
+
+        private static Dictionary<string, IDefinition> CreateDocIdIndex()
+        {
+            var referenceAssemblyPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                                                     "Reference Assemblies",
+                                                     "Microsoft",
+                                                     "Framework",
+                                                     ".NETFramework",
+                                                     "v4.6.1");
+
+            var assemblies = HostEnvironment.LoadAssemblySet(referenceAssemblyPath).ToArray();
+            var publicNamespaces = assemblies.SelectMany(a => a.GetAllNamespaces().Where(n => n.GetTypes().Any(t => t.IsVisibleOutsideAssembly())));
+            var publicTypes = assemblies.SelectMany(a => a.GetAllTypes().Where(t => t.IsVisibleOutsideAssembly()));
+            var publicMembers = publicTypes.SelectMany(t => t.Members.Where(m => m.IsVisibleOutsideAssembly()));
+            return publicNamespaces.Concat<IDefinition>(publicTypes)
+                                   .Concat(publicMembers)
+                                   .GroupBy(d => d.UniqueId())
+                                   .ToDictionary(g => g.Key, g => g.First());
+        }
+
+        private static Dictionary<(string docid, string namespaceName, string typeName, string signature), SortedSet<string>> ProcessFiles(string[] inputFiles, Dictionary<string, IDefinition> docIdIndex)
+        {
+            var result = new Dictionary<(string docid, string namespaceName, string typeName, string signature), SortedSet<string>>();
+
+            foreach (var inputFile in inputFiles)
+            {
+                var diagnosticId = Path.GetFileNameWithoutExtension(inputFile);
+                var docIds = GetDocIds(inputFile);
+                if (!docIds.Any())
+                {
+                    WriteError("Input file doesn't list any APIs.", inputFile);
+                }
+                else
+                {
+                    foreach (var (docId, lineNumber) in docIds)
+                    {
+                        if (!docIdIndex.TryGetValue(docId, out var api))
+                        {
+                            WriteError($"The API '{docId}' cannot be resolved.", $"{inputFile}({lineNumber})");
+                        }
+                        else
+                        {
+                            var namespaceName = api.GetNamespaceName();
+                            var typeName = api.GetTypeName();
+                            var signature = api.GetMemberSignature();
+
+                            var key = (docId, namespaceName, typeName, signature);
+
+                            if (!result.TryGetValue(key, out var diagnosticIds))
+                            {
+                                diagnosticIds = new SortedSet<string>();
+                                result.Add(key, diagnosticIds);
+                            }
+
+                            diagnosticIds.Add(diagnosticId);
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static void WriteResults(string outputPath, Dictionary<(string docid, string namespaceName, string typeName, string signature), SortedSet<string>> result)
+        {
+            using (var textWriter = File.CreateText(outputPath))
+            {
+                var writer = new CsvWriter(textWriter);
+                writer.Write("DocId");
+                writer.Write("Namespace");
+                writer.Write("Type");
+                writer.Write("Member");
+                writer.Write("DiagnosticIds");
+                writer.WriteLine();
+
+                foreach (var item in result.OrderBy(kv => kv.Key.namespaceName)
+                                           .ThenBy(kv => kv.Key.typeName)
+                                           .ThenBy(kv => kv.Key.signature))
+                {
+                    var list = string.Join(";", item.Value);
+
+                    writer.Write(item.Key.docid);
+                    writer.Write(item.Key.namespaceName);
+                    writer.Write(item.Key.typeName);
+                    writer.Write(item.Key.signature);
+                    writer.Write(list);
+                    writer.WriteLine();
+                }
+            }
+        }
+
+        private static (string docId, int line)[] GetDocIds(string fileName)
+        {
+            // We expect the input to be in the following form:
+            //
+            // <!--
+            // DocId
+            // DocId
+            // ...
+            // -->
+            // <Rest of file>
+
+            var result = new List<(string docId, int line)>();
+
+            using (var reader = File.OpenText(fileName))
+            {
+                var lineNumber = 1;
+                var hasSeenHeader = false;
+
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    line = line.Trim();
+
+                    if (!hasSeenHeader)
+                    {
+                        if (line == "<!--")
+                            hasSeenHeader = true;
+                    }
+                    else if (line == "-->")
+                    {
+                        // Found end of header block, so we're done.
+                        break;
+                    }
+                    else
+                    {
+                        result.Add((line, lineNumber));
+                    }
+
+                    lineNumber++;
+                }
+            }
+
+            return result.ToArray();
+        }
+    }
+}

--- a/src/dep-index/dep-index.csproj
+++ b/src/dep-index/dep-index.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.BuildTools.Cci" Version="1.0.0-prerelease-01423-01" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Terrajobst.Cci\Terrajobst.Cci.csproj" />
+    <ProjectReference Include="..\Terrajobst.Csv\Terrajobst.Csv.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This adds a generic analyzer that allows deprecating APIs. Adding deprecated APIs is easy. Simply add a document named `DEXXXX.md` (where *XXXX* is a four digit number) in the [docs](https://github.com/terrajobst/platform-compat/tree/master/docs) folder that looks like this:

```Markdown
<!--
T:SomeNamespace.SomeType
-->
# DEXXXX: Don't use SomeType

## Motivation

`SomeType` is a deprecated APIs. Don't use it or they will be
dragons.

## Recommendation

The replacement for `SomeType` is the `SomeOtherType`. It's not a
drop-in replacement, so make sure to consult the [docs](link).
```

The build will automatically create an index from these documents and report usages. It will use the doc as the help link.