### PR TITLE
Enable test running on the command line

### DIFF
--- a/platform-compat.sln
+++ b/platform-compat.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{3353F1
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
+		src\Testing.targets = src\Testing.targets
 		src\version.json = src\version.json
 	EndProjectSection
 EndProject

--- a/platform-compat.sln
+++ b/platform-compat.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.0
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrajobst.PlatformCompat.Analyzers.Vsix", "src\Terrajobst.PlatformCompat.Analyzers.Vsix\Terrajobst.PlatformCompat.Analyzers.Vsix.csproj", "{95368DD4-2B76-4304-B7EC-6E27C72F641B}"
 EndProject
@@ -20,6 +20,13 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terrajobst.PlatformCompat.Analyzers.Tests", "src\Terrajobst.PlatformCompat.Analyzers.Tests\Terrajobst.PlatformCompat.Analyzers.Tests.csproj", "{513A0D76-352B-4DF6-945A-358B0CB2EABA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrajobst.PlatformCompat.Scanner.Tests", "src\Terrajobst.PlatformCompat.Scanner.Tests\Terrajobst.PlatformCompat.Scanner.Tests.csproj", "{F77DF5B7-FC77-4DA7-BE7B-DC402DEDD064}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{3353F11E-B74D-44BD-9CF4-FD0A63A0C07B}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+		src\version.json = src\version.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,4 +4,6 @@
     <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.25" />
   </ItemGroup>
 
+  <Import Project="Testing.targets" Condition="$(AssemblyName.EndsWith('Tests'))" />
+
 </Project>

--- a/src/Terrajobst.PlatformCompat.Analyzers.Tests/Terrajobst.PlatformCompat.Analyzers.Tests.csproj
+++ b/src/Terrajobst.PlatformCompat.Analyzers.Tests/Terrajobst.PlatformCompat.Analyzers.Tests.csproj
@@ -11,8 +11,6 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" ExcludeAssets="All" />
     <PackageReference Include="System.Composition" Version="1.0.31" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <!-- This are fake references. They are only listed to ensure the machine has these packages

--- a/src/Terrajobst.PlatformCompat.Scanner.Tests/Terrajobst.PlatformCompat.Scanner.Tests.csproj
+++ b/src/Terrajobst.PlatformCompat.Scanner.Tests/Terrajobst.PlatformCompat.Scanner.Tests.csproj
@@ -8,8 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Testing.targets
+++ b/src/Testing.targets
@@ -1,0 +1,17 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.3.0-beta1-build3642" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" PrivateAssets="All" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <SkipTests Condition="'$(SkipTests)' == ''">$(BuildingInsideVisualStudio)</SkipTests>
+  </PropertyGroup>
+
+  <Target Name="RunTests" AfterTargets="AfterBuild" Condition="'$(SkipTests)' != 'True'">
+    <xunit Assemblies="$(TargetPath)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
First, this centralizes the package references that are needed for xUnit, including the VS and MSBuild test runners.

Secondly, it will run the tests from the command unless testing is disabled. Test executing after build will be disabled by AppVeyor (as AppVeyor already runs them) and when building inside of VS (because that's already done by Test Explorer).